### PR TITLE
fix: seed utility

### DIFF
--- a/src/tables/schema.ts
+++ b/src/tables/schema.ts
@@ -8,6 +8,7 @@ import { ITable, Table } from '../table'
 import { createTableInput } from './create-table-input'
 
 export class Schema {
+  public isDyngoose = true
   public options: Metadata.Table
 
   /**

--- a/src/utils/is.ts
+++ b/src/utils/is.ts
@@ -1,0 +1,5 @@
+import { Table } from '../table'
+
+export function isDyngooseTable(obj: any) {
+  return obj.prototype instanceof Table || (obj && obj.schema && obj.schema.isDyngoose)
+}

--- a/src/utils/migrate.ts
+++ b/src/utils/migrate.ts
@@ -2,6 +2,7 @@ import { readdirSync } from 'fs'
 import * as _ from 'lodash'
 import { join } from 'path'
 import { Table } from '../table'
+import { isDyngooseTable } from './is'
 
 export interface MigrateTablesInput {
   tablesDirectory: string
@@ -29,7 +30,7 @@ export default async function migrateTables(input: MigrateTablesInput) {
       const tableFileExports = require(tableFile)
 
       for (const exportedProperty of _.values(tableFileExports)) {
-        if (exportedProperty.prototype instanceof Table) {
+        if (isDyngooseTable(exportedProperty)) {
           tables.push(exportedProperty)
         }
       }


### PR DESCRIPTION
The seed utility did not work as expected.

Additionally added a new utility for determining if an object is a
Dyngoose Table class.

## Fix Seed Utility

#### Is it a breaking change?: NO

### Why did you make these changes?

To fix the seed utility, that was not working.

### What's changed in these changes?

Only utilities. Also exposed a new `isDyngoose` static property on the table schema class.

### What do you especially want to get reviewed?

N/A.

### Is there any other comments that every teammate should know?

N/A


### Submission Type

* [X] Bugfix
* [X] New Feature
* [ ] Refactor


### All Submissions

* [ ] Have you added an explanation of what your changes?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you checked potential side effects that could make bad impacts to other services?


### New Features

* [ ] Have you configured CI/CD properly?
* [ ] Have you configured optimal memory size and timeouts of Lambda Function?
* [ ] Have you grant required permissions (e.g. IAM Policy, VPC Security Group)?
* [ ] Have you made required resources (e.g. DynamoDB Table, RDS Cluster)?
* [ ] Does it requires native addons dependency?
