### PR TITLE
feat: remove moment in favor of using native Date functions

### DIFF
--- a/docs/Attributes.md
+++ b/docs/Attributes.md
@@ -81,9 +81,6 @@ The `Date` attribute supports additional settings:
   // store only the date, not the time, in a YYYY-MM-DD format
   dateOnly: true,
 
-  // manually specify a desired format for the value, uses `moment.format` internally
-  format: …,
-
   // sets the expiration time for this record, see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/TTL.html
   timeToLive: true,
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -959,9 +959,9 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.161",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.161.tgz",
-      "integrity": "sha512-EP6O3Jkr7bXvZZSZYlsgt5DIjiGr0dXP1/jVEwVLTFgg0d+3lWVQkRavYVQszV7dYUwvg0B8R0MBDpcmXg7XIA==",
+      "version": "4.14.162",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.162.tgz",
+      "integrity": "sha512-alvcho1kRUnnD1Gcl4J+hK0eencvzq9rmzvFPRmP5rPHx9VVsJj6bKLTATPVf9ktgv4ujzh7T+XWKp+jhuODig==",
       "dev": true
     },
     "@types/minimist": {
@@ -3767,11 +3767,6 @@
       "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
       "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
       "dev": true
-    },
-    "moment": {
-      "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.27.0.tgz",
-      "integrity": "sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ=="
     },
     "ms": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@semantic-release/changelog": "5.0.1",
     "@semantic-release/git": "^9.0.0",
     "@types/chai": "4.2.12",
-    "@types/lodash": "4.14.161",
+    "@types/lodash": "^4.14.162",
     "@types/mocha": "8.0.3",
     "@types/node": "14.0.27",
     "aws-sdk": "^2.627.0",
@@ -59,8 +59,7 @@
   "dependencies": {
     "amazon-dax-client": "^1.2.2",
     "aws-xray-sdk-core": "^3.0.0",
-    "lodash": "^4.17.15",
-    "moment": "^2.24.0"
+    "lodash": "^4.17.15"
   },
   "config": {
     "commitizen": {

--- a/src/decorator/attribute-types/date.ts
+++ b/src/decorator/attribute-types/date.ts
@@ -1,5 +1,4 @@
 import { DynamoDB } from 'aws-sdk'
-import * as moment from 'moment'
 import { DynamoAttributeType } from '../../dynamo-attribute-types'
 import { SchemaError } from '../../errors'
 import { IAttributeType } from '../../interfaces/attribute-type.interface'
@@ -58,43 +57,41 @@ export class DateAttributeType extends AttributeType<Value, Metadata> implements
     }
   }
 
-  fromDynamo(attributeValue: DynamoDB.AttributeValue) {
+  fromDynamo(attributeValue: DynamoDB.AttributeValue): Value | undefined {
     // whenever the value is stored as a number, it must be a timestamp
     // the timestamp will have been stored in UTC
     if (attributeValue.N) {
       if (this.metadata.millisecondTimestamp) {
         return new Date(stringToNumber(attributeValue.N))
-      } else {
-        // the timestamp will be converted from UTC (as all timestamps as in UTC), to the local time
-        // so we need to convert it back to UTC to ensure all dates read from the database as in UTC
-        return moment.unix(stringToNumber(attributeValue.N)).utc().toDate()
+      } else if (this.metadata.unixTimestamp || this.metadata.timeToLive) {
+        return new Date(stringToNumber(attributeValue.N) * 1000)
       }
     } else if (attributeValue.S) {
-      if (this.metadata.dateOnly) {
-        return moment.utc(attributeValue.S as string, 'YYYY-MM-DD', true).toDate()
-      } else {
-        return moment.utc(attributeValue.S as string, this.metadata.format || moment.ISO_8601, true).toDate()
-      }
+      return new Date(attributeValue.S as string)
     }
   }
 
-  fromJSON(dt: moment.MomentInput) {
-    // TODO: this might not be the best way to parse dates, and it doesn't currently handle invalid dates well
-    return moment.utc(dt).toDate()
+  fromJSON(dt: string | number): Value {
+    if (this.metadata.unixTimestamp || this.metadata.timeToLive) {
+      return new Date(stringToNumber(dt) * 1000)
+    } else if (this.metadata.millisecondTimestamp) {
+      return new Date(stringToNumber(dt))
+    } else {
+      return new Date(dt as string)
+    }
   }
 
   toJSON(dt: Value): string | number {
-    const m = moment.utc(dt)
     if (this.metadata.unixTimestamp || this.metadata.timeToLive) {
-      return m.unix()
+      // the Math.floor gets rid of the decimal places, which would corrupt the value when being saved
+      return Math.floor(dt.valueOf() / 1000)
     } else if (this.metadata.millisecondTimestamp) {
-      return m.valueOf()
+      return dt.valueOf()
     } else if (this.metadata.dateOnly) {
-      return m.format('YYYY-MM-DD')
-    } else if (this.metadata.format) {
-      return m.format(this.metadata.format as string)
+      // grab the ISO string, then split at the time (T) separator and grab only the date
+      return dt.toISOString().split('T')[0]
     } else {
-      return moment.utc(dt).toISOString()
+      return dt.toISOString()
     }
   }
 }

--- a/src/decorator/attribute-types/utils.spec.ts
+++ b/src/decorator/attribute-types/utils.spec.ts
@@ -1,0 +1,15 @@
+import { expect } from 'chai'
+import { stringToNumber } from './utils'
+
+describe('AttributeType/Utils', () => {
+  describe('stringToNumber', () => {
+    it('should convert strings to numbers', () => {
+      expect(stringToNumber('1000')).to.eq(1000)
+      expect(stringToNumber('1000.50')).to.eq(1000.5)
+
+      // it also accepts numbers and returns them without changing them
+      expect(stringToNumber(1000)).to.eq(1000)
+      expect(stringToNumber(1000.50)).to.eq(1000.5)
+    })
+  })
+})

--- a/src/decorator/attribute-types/utils.ts
+++ b/src/decorator/attribute-types/utils.ts
@@ -1,31 +1,11 @@
-export function stringToNumber(number: string): number {
-  return JSON.parse(number)
+export function stringToNumber(number: number | string): number {
+  if (typeof number === 'number') {
+    return number
+  } else {
+    return JSON.parse(number)
+  }
 }
 
 export function numberToString(number: number | BigInt) {
   return number.toString()
-}
-
-export function transformString(value: string) {
-  // if (!this.dynamoTypes.includes(AttributeType.Boolean) && !_.isString(value)) {
-  //   if (_.isNil(value)) {
-  //     value = ''
-  //   } else {
-  //     value = value.toString()
-  //   }
-  // }
-
-  if (this.options.trim) {
-    value = value.trim()
-  }
-
-  if (this.options.lowercase) {
-    value = value.toLowerCase()
-  }
-
-  if (this.options.uppercase) {
-    value = value.toUpperCase()
-  }
-
-  return value
 }

--- a/src/metadata/attribute-types/date.metadata.ts
+++ b/src/metadata/attribute-types/date.metadata.ts
@@ -1,35 +1,24 @@
-import * as moment from 'moment'
 import { AttributeMetadata } from '../attribute'
 
 export interface DateAttributeMetadata extends AttributeMetadata<Date> {
   /**
-   * Specify the format you want Moment to store values in, by default
-   * it will use moment.ISO_8601 format. You can also use some of the
-   * other options to change the format, such as:
-   *
-   * * dateOnly will use YYYY-MM-DD format
-   * * timestamp will store values as Unix timestamps
+   * When true, stores only the date part of the Date value in an
+   * ISO 8601 compliant format of YYYY-MM-DD.
    */
-  format?: string | moment.MomentBuiltinFormat
-
-  /**
-  * When true, stores only the date part of the Date value in an
-  * ISO 8601 compliant format of YYYY-MM-DD.
-  */
   dateOnly?: boolean
 
   /**
-  * When true, stores value as a Unix timestamp values.
-  */
+   * When true, stores value as a Unix timestamp values.
+   */
   unixTimestamp?: boolean
 
   /**
-  * When true, value is stored as a timestamp consistent with JavaScript's Date.now()
-  * style of the number of milliseconds elapsed since 1 January 1970 00:00:00 UTC.
-  *
-  * This is especially useful if you area using the timestamp as part of a RANGE key
-  * on a Table's PrimaryKey and you need to ensure the timestamps are unique.
-  */
+   * When true, value is stored as a timestamp consistent with JavaScript's Date.now()
+   * style of the number of milliseconds elapsed since 1 January 1970 00:00:00 UTC.
+   *
+   * This is especially useful if you area using the timestamp as part of a RANGE key
+   * on a Table's PrimaryKey and you need to ensure the timestamps are unique.
+   */
   millisecondTimestamp?: boolean
 
   /**
@@ -46,7 +35,7 @@ export interface DateAttributeMetadata extends AttributeMetadata<Date> {
   /**
    * When true, the value will be automatically set the current date & time
    * when a new record is created.
-  */
+   */
   nowOnCreate?: boolean
 
   /**

--- a/src/metadata/attribute-types/moment.metadata.ts
+++ b/src/metadata/attribute-types/moment.metadata.ts
@@ -1,7 +1,0 @@
-import * as moment from 'moment'
-import { AttributeMetadata } from '../attribute'
-
-export type MomentAttributeValue = moment.Moment
-
-export interface MomentAttributeMetadata extends AttributeMetadata<MomentAttributeValue> {
-}

--- a/src/query/primary-key.ts
+++ b/src/query/primary-key.ts
@@ -1,6 +1,5 @@
 import { DynamoDB } from 'aws-sdk'
 import { get, has, isArray } from 'lodash'
-import * as moment from 'moment'
 import { QueryError } from '../errors'
 import * as Metadata from '../metadata'
 import { ITable, Table } from '../table'
@@ -11,7 +10,7 @@ import { buildQueryExpression } from './expression'
 import { Filters as QueryFilters, UpdateConditions } from './filters'
 import { Results as QueryResults } from './results'
 
-type PrimaryKeyType = string | number | Date | moment.Moment
+type PrimaryKeyType = string | number | Date
 type RangePrimaryKeyType = PrimaryKeyType | void
 
 type PrimaryKeyBatchInput<HashKeyType extends PrimaryKeyType, RangeKeyType extends RangePrimaryKeyType> = [HashKeyType, RangeKeyType]

--- a/src/table.ts
+++ b/src/table.ts
@@ -533,10 +533,12 @@ export class Table {
       const propertyName = attribute.propertyName
       const value = this.getAttribute(attributeName)
 
-      if (_.isFunction(attribute.type.toJSON)) {
-        json[propertyName] = attribute.type.toJSON(value, attribute)
-      } else {
-        json[propertyName] = value
+      if (!isTrulyEmpty(value)) {
+        if (_.isFunction(attribute.type.toJSON)) {
+          json[propertyName] = attribute.type.toJSON(value, attribute)
+        } else {
+          json[propertyName] = value
+        }
       }
     }
 

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,17 +1,4 @@
 {
-    "compilerOptions": {
-        "module": "commonjs",
-        "target": "es2017",
-        "noImplicitAny": true,
-        "sourceMap": true,
-        "declaration": false,
-        "outDir": "dist",
-        "emitDecoratorMetadata": true,
-        "experimentalDecorators": true,
-        "strictNullChecks": true,
-        "diagnostics": true
-    },
-    "include": [
-        "src/**/*"
-    ]
+    "extends": "./tsconfig.json",
+    "exclude": []
 }


### PR DESCRIPTION
Since momentjs published the library will no longer be in active
development, it made me look at whether Dyngoose really needed to use
momentjs for anything. The truth is that it did not.

The @Dyngoose.Attribute.Moment() was not being exposed like other
attribute types and the only other use of moment was in the Date
attribute for handling some really basic formatting and parsing, all of
which is possible using native Date functions and is quite reliable
within Node.js.

## Remove moment.js

#### Is it a breaking change?: NO

### Why did you make these changes?

Moment.js 

### What's changed in these changes?

This should be almost completely backwards compatible, other than the `format` option on `Date` attribute types. The `format` option has been removed because it is too complicated to support and I expect it was not being used by anyone, since the useful formats (timestamps) are exposed as other options and otherwise it makes sense to store all dates in standard ISO formats.

### What do you especially want to get reviewed?

N/A

### Is there any other comments that every teammate should know?

N/A

### Submission Type

* [ ] Bugfix
* [ ] New Feature
* [X] Refactor

### All Submissions

* [X] Have you added an explanation of what your changes?
* [X] Have you written new tests for your changes, as applicable?
* [X] Have you checked potential side effects that could make bad impacts to other services?


### New Features

* [ ] Have you configured CI/CD properly?
* [ ] Have you configured optimal memory size and timeouts of Lambda Function?
* [ ] Have you grant required permissions (e.g. IAM Policy, VPC Security Group)?
* [ ] Have you made required resources (e.g. DynamoDB Table, RDS Cluster)?
* [ ] Does it requires native addons dependency?
