### PR TITLE
fix: 🐛 Billing mode pay per request for GSIs

### DIFF
--- a/src/tables/create-table-input.ts
+++ b/src/tables/create-table-input.ts
@@ -158,10 +158,15 @@ export function createTableInput(schema: Schema, forCloudFormation = false): Dyn
         Projection: {
           ProjectionType: indexMetadata.projection == null ? 'ALL' : indexMetadata.projection,
         },
-        ProvisionedThroughput: {
+      }
+
+      if (schema.options.billingMode === 'PAY_PER_REQUEST') {
+        index.BillingMode = 'PAY_PER_REQUEST'
+      } else {
+        index.ProvisionedThroughput = {
           ReadCapacityUnits: throughput.read,
           WriteCapacityUnits: throughput.write,
-        },
+        }
       }
 
       if (indexMetadata.nonKeyAttributes != null && indexMetadata.nonKeyAttributes.length > 0) {


### PR DESCRIPTION
## BACKEND-STORY_ID One-sentence summary of changes
The indexes currently have no way to set pay per request throughput

#### Is it a breaking change?: NO

### Why did you make these changes?
The indexes currently have no way to set pay per request throughput

### What's changed in these changes?

Added a similar change that was used for the table on the index as well.

### What do you especially want to get reviewed?



### Submission Type

* [x ] Bugfix
* [ ] New Feature
* [ ] Refactor

### All Submissions

* [x ] Have you added an explanation of what your changes?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you checked potential side effects that could make bad impacts to other services?


### New Features

* [ ] Have you configured CI/CD properly?
* [ ] Have you configured optimal memory size and timeouts of Lambda Function?
* [ ] Have you grant required permissions (e.g. IAM Policy, VPC Security Group)?
* [ ] Have you made required resources (e.g. DynamoDB Table, RDS Cluster)?
* [ ] Does it requires native addons dependency?
