### PR TITLE
feat: utility to update sets more intelligently

### DIFF
--- a/src/setup-tests.spec.ts
+++ b/src/setup-tests.spec.ts
@@ -49,6 +49,9 @@ export class TestableTable extends Dyngoose.Table {
   @Dyngoose.Attribute.String()
   public testString: string
 
+  @Dyngoose.Attribute.StringSet()
+  public testStringSet: string[]
+
   @Dyngoose.Attribute.String({ lowercase: true })
   public lowercaseString: string
 

--- a/src/table.spec.ts
+++ b/src/table.spec.ts
@@ -24,14 +24,14 @@ describe('Table', () => {
     }
   })
 
-  describe('.del', () => {
-    it('should allow attributes to be deleted', async () => {
+  describe('.remove', () => {
+    it('should allow attributes to be removed', async () => {
       const card = TestableTable.new()
       card.id = 101
       card.title = '101'
       card.generic = 'something'
-      card.del('generic')
-      card.del('testString')
+      card.remove('generic')
+      card.remove('testString')
       card.testString = 'value is set'
 
       await card.save()
@@ -47,6 +47,38 @@ describe('Table', () => {
         expect(reloadedCard.defaultedString).to.eq('SomeDefault')
         expect(reloadedCard.testString).to.eq('value is set')
       }
+    })
+  })
+
+  describe('.updateSet', () => {
+    it('should update a set', async () => {
+      const card = TestableTable.new({
+        id: 98,
+        title: '98',
+        testStringSet: [
+          '',
+          'test',
+          'strings',
+        ],
+        testNumberSet: [
+          1,
+          2,
+          3,
+        ],
+      })
+
+      expect(card.testStringSet).to.deep.eq(['', 'test', 'strings'])
+      expect(card.testNumberSet).to.deep.eq([1, 2, 3])
+
+      card.updateSet('testStringSet', ['', 'test', 'test', 'abc'])
+
+      expect(card.testStringSet).to.deep.eq(['test', 'abc'], 'set was cleaned by updateSet')
+
+      card.updateSet('testStringSet', ['abc', 'test'])
+      card.updateSet('testNumberSet', [3, 2, 1])
+
+      expect(card.testStringSet).to.deep.eq(['test', 'abc'], 'set should not have been changed')
+      expect(card.testNumberSet).to.deep.eq([1, 2, 3], 'set should not have been changed')
     })
   })
 

--- a/src/table.ts
+++ b/src/table.ts
@@ -510,7 +510,7 @@ export class Table {
 
   /**
    * Sets (StringSet, NumberSet, and BinarySet) in DynamoDB have some unique rules:
-   * 
+   *
    * Each value within a set must be unique.
    * The order of the values within a set is not preserved.
    *
@@ -519,12 +519,17 @@ export class Table {
    */
   public updateSet<P extends SetTableProperty<this>>(propertyName: P, set: SetValue, clean = true): this {
     const newSet: any = clean ? _.filter(_.uniq(set as any)) : set
-    const currentSet = this.get(propertyName as any) as any as string[]
-  
-    if (!currentSet || currentSet.length === 0) {
-      this.set(propertyName as any, newSet)
-    } else if (_.intersection(currentSet, newSet).length !== newSet.length) {
-      this.set(propertyName as any, newSet)
+
+    if (newSet.length > 0) {
+      const currentSet = this.get(propertyName as any) as any
+
+      if (
+        currentSet == null ||
+        currentSet.length === 0 ||
+        _.intersection(currentSet, newSet).length !== newSet.length
+      ) {
+        this.set(propertyName as any, newSet)
+      }
     }
 
     return this

--- a/src/tables/properties.ts
+++ b/src/tables/properties.ts
@@ -1,6 +1,15 @@
+import { BinarySetAttributeValue } from 'aws-sdk/clients/dynamodb'
 import { Table } from '../table'
 
-export type TableProperty<T> = Exclude<Exclude<keyof T, keyof Table>, Function>
+export type TableProperty<T> = Exclude<keyof T, keyof Table>
+
+type KeyOfType<T, V> = keyof {
+  [P in keyof T as T[P] extends V ? P : never]: any
+}
+
+export type SetValue = string[] | (BigInt | number)[] | BinarySetAttributeValue[]
+
+export type SetTableProperty<T> = KeyOfType<T, SetValue>
 
 export type TableProperties<T> = {
   [key in TableProperty<T>]?: T[key]

--- a/src/tables/properties.ts
+++ b/src/tables/properties.ts
@@ -7,7 +7,7 @@ type KeyOfType<T, V> = keyof {
   [P in keyof T as T[P] extends V ? P : never]: any
 }
 
-export type SetValue = string[] | (BigInt | number)[] | BinarySetAttributeValue[]
+export type SetValue = string[] | Array<BigInt | number> | BinarySetAttributeValue[]
 
 export type SetTableProperty<T> = KeyOfType<T, SetValue>
 


### PR DESCRIPTION
#### Is it a breaking change?: NO

### Why did you make these changes?

Dyngoose tries keep track of "changed" properties, so when saving, it
can intelligently perform an UpdateItem operation. Sets pose some
complications. Sets in Dyngoose do not retain the order of the items
within the set and they cannot contain duplicates. So this PR adds a
utility function to update sets intelligently.

I've attempted to add strict typing, however, TypeScript compiler fails
to understand the complexity so I had to cop out a bit.

### What's changed in these changes?

Added a utility `upsetSet` method to the `Table` class.

### Submission Type

* [ ] Bugfix
* [X] New Feature
* [ ] Refactor

### All Submissions

* [X] Have you added an explanation of what your changes?
* [X] Have you written new tests for your changes, as applicable?
* [X] Have you checked potential side effects that could make bad impacts to other services?
