### PR TITLE
feat: use autoscaling throughout without specifying read/write capacity

### DIFF
--- a/src/interfaces/throughput.interface.ts
+++ b/src/interfaces/throughput.interface.ts
@@ -7,15 +7,36 @@ type IThroughputTargetUtilization = 20
 | 71 | 72 | 73 | 74 | 75 | 76 | 77 | 78 | 79 | 80
 | 81 | 82 | 83 | 84 | 85 | 86 | 87 | 88 | 89 | 90
 
-interface IThroughputAutoScalingCapacity {
+export interface IThroughputAutoScalingCapacity {
   // these apply to both read and write
   targetUtilization: IThroughputTargetUtilization // defaults to 70
   minCapacity: number // defaults to 5 units
   maxCapacity: number // defaults to 40000 units
 }
 
-export interface IThroughput {
+interface IStaticThroughput {
   read: number
   write: number
-  autoScaling?: true | IThroughputAutoScalingCapacity | { read: IThroughputAutoScalingCapacity, write: IThroughputAutoScalingCapacity }
+  autoScaling?: void
 }
+
+interface IAutoScalingThroughputFields {
+  read?: void
+  write?: void
+
+  /**
+   * Tries to enable auto scaling for this table.
+   *
+   * Note: You cannot actually create a table with autoscaling enabled by
+   * default, so the process requires you to create a provisioned table and then
+   * enable autoscaling has to be enabled later.
+   *
+   * WARNING: Dyngoose DOES NOT automatically enable auto-scaling when using the
+   * `Table.createTable` utility! Use the CloudFormation template generator.
+   *
+   * @see {@link https://aws.amazon.com/blogs/database/how-to-use-aws-cloudformation-to-configure-auto-scaling-for-amazon-dynamodb-tables-and-indexes/}
+   */
+  autoScaling: true | IThroughputAutoScalingCapacity | { read: IThroughputAutoScalingCapacity, write: IThroughputAutoScalingCapacity }
+}
+
+export type IThroughput = IStaticThroughput | IAutoScalingThroughputFields

--- a/src/tables/create-table-input.ts
+++ b/src/tables/create-table-input.ts
@@ -25,8 +25,8 @@ export function createTableInput(schema: Schema, forCloudFormation = false): Dyn
     params.BillingMode = 'PAY_PER_REQUEST'
   } else {
     params.ProvisionedThroughput = {
-      ReadCapacityUnits: schema.throughput.read,
-      WriteCapacityUnits: schema.throughput.write,
+      ReadCapacityUnits: schema.throughput.read ?? 5,
+      WriteCapacityUnits: schema.throughput.write ?? 5,
     }
   }
 
@@ -162,8 +162,8 @@ export function createTableInput(schema: Schema, forCloudFormation = false): Dyn
 
       if (schema.options.billingMode !== 'PAY_PER_REQUEST') {
         index.ProvisionedThroughput = {
-          ReadCapacityUnits: throughput.read,
-          WriteCapacityUnits: throughput.write,
+          ReadCapacityUnits: throughput.read ?? 5,
+          WriteCapacityUnits: throughput.write ?? 5,
         }
       }
 

--- a/src/tables/schema.ts
+++ b/src/tables/schema.ts
@@ -46,8 +46,6 @@ export class Schema {
     this.options = metadata
 
     this.setThroughput(this.options.throughput != null ? this.options.throughput : {
-      read: 5,
-      write: 5,
       autoScaling: {
         targetUtilization: 70,
         minCapacity: 5,


### PR DESCRIPTION
This is still incomplete, as the cloudformation template utility does
not currently create the autoscaling policies. That functionality will
come later.

Fixes #544

## BACKEND-STORY_ID One-sentence summary of changes

#### Is it a breaking change?: NO

### Why did you make these changes?

Improves the typing for when you want to use autoscaling for tables and indexes.

### What's changed in these changes?

Type interfaces for throughouts.

### Submission Type

* [ ] Bugfix
* [ ] New Feature
* [X] Refactor
