### PR TITLE
fix: downgrade to DynamoDB Local 1.16.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     timeout-minutes: 15
     services:
       dynamodb:
-        image: amazon/dynamodb-local
+        image: amazon/dynamodb-local:1.16.0
         # @note Github overwrites WORKDIR to repository path, so overwrite that again
         options: >-
           --workdir /home/dynamodblocal


### PR DESCRIPTION
It looks like something broke in 1.17.0 that still is not fixed.
Probably should move to using localstack in the future…
