### PR TITLE
#670 Added abort signal support for dynamo readonly functions

### DIFF
--- a/src/batch-get.spec.ts
+++ b/src/batch-get.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai'
+import { expect, should } from 'chai'
 import { sortBy } from 'lodash'
 import { BatchGet } from './batch-get'
 import { PrimaryKey } from './query/primary-key'
@@ -141,6 +141,25 @@ describe('BatchGet', () => {
     // now verify the results
     expect(results.length).eq(1)
     expect(results[0].id).eq(1)
+  })
+
+  it('should not return records when aborted', async () => {
+    const abortController = new AbortController()
+    const batch = new BatchGet<TestTable1>()
+    batch.get(TestTable1.primaryKey.fromKey(1))
+    batch.get(TestTable1.primaryKey.fromKey(42))
+    abortController.abort()
+
+    let exception
+    try {
+      await batch.retrieve({
+        abortSignal: abortController.signal,
+      })
+    } catch (ex) {
+      exception = ex
+    }
+
+    should().exist(exception)
   })
 
   it('should accept projection expressions', async () => {

--- a/src/connections/index.ts
+++ b/src/connections/index.ts
@@ -1,2 +1,3 @@
 export * from './connection'
 export * from './dynamodb-connection'
+export * from './request-options'

--- a/src/connections/request-options.ts
+++ b/src/connections/request-options.ts
@@ -1,0 +1,7 @@
+export interface IRequestOptions {
+  abortSignal?: AbortSignal
+}
+
+export function isRequestOptions(value: unknown): value is IRequestOptions {
+  return typeof value === 'object' && value != null && 'abortSignal' in value
+}

--- a/src/query/global-secondary-index.spec.ts
+++ b/src/query/global-secondary-index.spec.ts
@@ -90,6 +90,23 @@ describe('Query/GlobalSecondaryIndex', () => {
         expect(res.records[1].id).to.eq(11)
       })
 
+      it('should not return items when aborted', async () => {
+        const abortController = new AbortController()
+        await Card.new({ id: 10, title: 'abc' }).save()
+        await Card.new({ id: 11, title: 'abd' }).save()
+        await Card.new({ id: 12, title: 'abd' }).save()
+        abortController.abort()
+
+        let exception
+        try {
+          await Card.hashTitleIndex.query({ title: 'abd' }, undefined, { abortSignal: abortController.signal })
+        } catch (ex) {
+          exception = ex
+        }
+
+        should().exist(exception)
+      })
+
       it('should return an empty array when no items match', async () => {
         const res = await Card.hashTitleIndex.query({ title: '404' })
         expect(res[0]).to.not.eq(null)
@@ -173,6 +190,20 @@ describe('Query/GlobalSecondaryIndex', () => {
         expect(res1.records.map((r) => r.id)).to.have.all.members(cardIds)
         expect(cardIds).to.include.members(res2.records.map((r) => r.id))
         expect(cardIds).to.include.members(res3.records.map((r) => r.id))
+      })
+
+      it('should not return results when aborted', async () => {
+        const abortController = new AbortController()
+        abortController.abort()
+
+        let exception
+        try {
+          await Card.hashTitleIndex.scan(null, undefined, { abortSignal: abortController.signal })
+        } catch (ex) {
+          exception = ex
+        }
+
+        should().exist(exception)
       })
     })
   })

--- a/src/query/local-secondary-index.ts
+++ b/src/query/local-secondary-index.ts
@@ -8,6 +8,7 @@ import { buildQueryExpression } from './expression'
 import { type Filters as QueryFilters } from './filters'
 import { QueryOutput } from './output'
 import { MagicSearch, type MagicSearchInput } from './search'
+import { type IRequestOptions } from '../connections'
 
 interface LocalSecondaryIndexQueryInput {
   rangeOrder?: 'ASC' | 'DESC'
@@ -50,7 +51,7 @@ export class LocalSecondaryIndex<T extends Table> {
     return queryInput
   }
 
-  public async query(filters: QueryFilters<T>, input: LocalSecondaryIndexQueryInput = {}): Promise<QueryOutput<T>> {
+  public async query(filters: QueryFilters<T>, input: LocalSecondaryIndexQueryInput = {}, requestOptions?: IRequestOptions): Promise<QueryOutput<T>> {
     if (!has(filters, this.tableClass.schema.primaryKey.hash.propertyName)) {
       throw new QueryError('Cannot perform a query on a LocalSecondaryIndex without specifying a hash key value')
     }
@@ -70,7 +71,7 @@ export class LocalSecondaryIndex<T extends Table> {
     const hasProjection = queryInput.ProjectionExpression == null
     let output: QueryCommandOutput
     try {
-      output = await this.tableClass.schema.dynamo.query(queryInput)
+      output = await this.tableClass.schema.dynamo.query(queryInput, requestOptions)
     } catch (ex) {
       throw new HelpfulError(ex, this.tableClass, queryInput)
     }
@@ -91,7 +92,7 @@ export class LocalSecondaryIndex<T extends Table> {
     return scanInput
   }
 
-  public async scan(filters: QueryFilters<T> | undefined | null, input: LocalSecondaryIndexScanInput = {}): Promise<QueryOutput<T>> {
+  public async scan(filters: QueryFilters<T> | undefined | null, input: LocalSecondaryIndexScanInput = {}, requestOptions?: IRequestOptions): Promise<QueryOutput<T>> {
     const scanInput = this.getScanInput(input)
     if (filters != null && Object.keys(filters).length > 0) {
       // don't pass the index metadata, avoids KeyConditionExpression
@@ -103,7 +104,7 @@ export class LocalSecondaryIndex<T extends Table> {
     const hasProjection = scanInput.ProjectionExpression == null
     let output: ScanCommandOutput
     try {
-      output = await this.tableClass.schema.dynamo.scan(scanInput)
+      output = await this.tableClass.schema.dynamo.scan(scanInput, requestOptions)
     } catch (ex) {
       throw new HelpfulError(ex, this.tableClass, scanInput)
     }

--- a/src/query/primary-key.ts
+++ b/src/query/primary-key.ts
@@ -170,14 +170,14 @@ export class PrimaryKey<T extends Table, HashKeyType extends PrimaryKeyType, Ran
    *
    * @deprecated
    */
-  public async batchGet(inputs: Array<PrimaryKeyBatchInput<HashKeyType, RangeKeyType>>, requestOptions?: IRequestOptions): Promise<T[]> {
+  public async batchGet(inputs: Array<PrimaryKeyBatchInput<HashKeyType, RangeKeyType>>): Promise<T[]> {
     const batch = new BatchGet<T>()
 
     for (const input of inputs) {
       batch.get(this.fromKey(input[0], input[1]))
     }
 
-    return await batch.retrieve(requestOptions)
+    return await batch.retrieve()
   }
 
   /**

--- a/src/table.ts
+++ b/src/table.ts
@@ -21,6 +21,7 @@ import { migrateTable } from './tables/migrate-table'
 import { type TablePropertyValue, type TableProperties, type TableProperty } from './tables/properties'
 import { Schema } from './tables/schema'
 import { isTrulyEmpty } from './utils/truly-empty'
+import { type IRequestOptions } from './connections'
 
 type StaticThis<T> = new() => T
 
@@ -142,8 +143,8 @@ export class Table {
     return await deleteTable(this.schema)
   }
 
-  public static async describeTable(): Promise<TableDescription> {
-    return await describeTable(this.schema)
+  public static async describeTable(requestOptions?: IRequestOptions): Promise<TableDescription> {
+    return await describeTable(this.schema, requestOptions)
   }
   // #endregion static methods
   // #endregion static

--- a/src/tables/describe-table.ts
+++ b/src/tables/describe-table.ts
@@ -1,11 +1,12 @@
 import { type DescribeTableCommandInput, type TableDescription } from '@aws-sdk/client-dynamodb'
 import { type Schema } from './schema'
+import { type IRequestOptions } from '../connections'
 
-export async function describeTable(schema: Schema): Promise<TableDescription> {
+export async function describeTable(schema: Schema, requestOptions?: IRequestOptions): Promise<TableDescription> {
   const params: DescribeTableCommandInput = {
     TableName: schema.name,
   }
 
-  const result = await schema.dynamo.describeTable(params)
+  const result = await schema.dynamo.describeTable(params, requestOptions)
   return result.Table as TableDescription
 }


### PR DESCRIPTION
## 670 Added abort signal support
#### Is it a breaking change?: NO

### Why did you make these changes?

To be able to abort long queries

### What's changed in these changes?

I added IRequestOptions interface and added usage of this interface to all get/query/scan functions.

### What do you especially want to get reviewed?

If the naming is as you like and if the way I implmented it is, is according to your design principles

### Is there any other comments that every teammate should know?


### Submission Type

* [ ] Bugfix
* [X ] New Feature
* [ ] Refactor

### All Submissions

* [ ] Have you added an explanation of what your changes?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you checked potential side effects that could make bad impacts to other services?


### New Features

* [ ] Have you configured CI/CD properly?
* [ ] Have you configured optimal memory size and timeouts of Lambda Function?
* [ ] Have you grant required permissions (e.g. IAM Policy, VPC Security Group)?
* [ ] Have you made required resources (e.g. DynamoDB Table, RDS Cluster)?
* [ ] Does it requires native addons dependency?
