### PR TITLE
Enhance transactWriteItems error handling with HelpfulError wrapping

### DIFF
--- a/src/query/transact-write.ts
+++ b/src/query/transact-write.ts
@@ -1,5 +1,6 @@
 import { type DynamoDB, type TransactWriteItemsOutput, type TransactWriteItem } from '@aws-sdk/client-dynamodb'
 import { chunk } from 'lodash'
+import { HelpfulError } from '../errors'
 
 // this is limit of dynamoDB
 const MAX_ITEMS = 25
@@ -11,9 +12,13 @@ export async function transactWrite(
   const chunks = chunk(requests, MAX_ITEMS)
   await Promise.all(
     chunks.map(async (transactItems) => {
-      return await documentClient.transactWriteItems({
-        TransactItems: transactItems,
-      })
+      try {
+        return await documentClient.transactWriteItems({
+          TransactItems: transactItems,
+        })
+      } catch (ex) {
+        throw new HelpfulError(ex, undefined, { TransactItems: transactItems })
+      }
     }),
   )
 


### PR DESCRIPTION
BACKEND-STORY_ID Wrapped chunked transactWriteItems calls with helpful error handling

Is it a breaking change?: NO

### Why did you make these changes?

When transactWriteItems fails, the error message is often opaque. Wrapping each chunked call with HelpfulError ensures transaction errors include Dyngoose-styled stack traces and request context, making debugging significantly easier.

### What’s changed in these changes?

I wrapped each chunked transactWriteItems call with HelpfulError, adding chunk metadata, request context, and improved error details for failing operations.

### What do you especially want to get reviewed?

The way error context and chunk details are captured and exposed in the error message.

### Is there any other comments that every teammate should know?

This change is non-breaking. Developers will now see more informative error messages when transactions fail.

### Submission Type

* [ ] Bugfix  
* [x] New Feature  
* [ ] Refactor

### All Submissions

* [x] Have you added an explanation of what your changes?  
* [ ] Have you written new tests for your changes, as applicable?  
* [x] Have you checked potential side effects that could make bad impacts to other services?


### New Features

* [ ] Have you configured CI/CD properly?  
* [ ] Have you configured optimal memory size and timeouts of Lambda Function?  
* [ ] Have you grant required permissions (e.g. IAM Policy, VPC Security Group)?  
* [ ] Have you made required resources (e.g. DynamoDB Table, RDS Cluster)?  
* [ ] Does it requires native addons dependency?